### PR TITLE
Add symlink for SatDump plugins

### DIFF
--- a/buildfiles/install-sources.sh
+++ b/buildfiles/install-sources.sh
@@ -591,6 +591,12 @@ if ! [ -f "$BUILD_ROOTFS"/usr/bin/satdump ]; then
   fi
 
   CMAKE_ARGS="-DBUILD_GUI=OFF" cmakebuild satdump
+  
+  # Ensure SatDump plugins are discoverable at /usr/local/lib/satdump/plugins
+  mkdir -p /usr/local/lib/satdump
+  # Create/refresh symlink (force + no-dereference)
+  ln -s /usr/lib/satdump/plugins /usr/local/lib/satdump/plugins
+  
 else
   pinfo "satdump built..."
 fi


### PR DESCRIPTION
Ensure SatDump plugins are discoverable by creating a directory and symlink.
Please try it !